### PR TITLE
fix: complete pnpm build-script allowlist (add core-js + pnpm 11)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,16 @@
-onlyBuiltDependencies:
+onlyBuiltDependencies:   # pnpm 10
   - "@tailwindcss/oxide"
   - better-sqlite3
+  - core-js
   - esbuild
   - protobufjs
   - sharp
   - unrs-resolver
+allowBuilds:             # pnpm 11
+  "@tailwindcss/oxide": true
+  better-sqlite3: true
+  core-js: true
+  esbuild: true
+  protobufjs: true
+  sharp: true
+  unrs-resolver: true


### PR DESCRIPTION
## Problem

The existing `pnpm-workspace.yaml` allowlist was incomplete:

1. **Missing `core-js`** — a fresh `pnpm install` still errored:
   ```
   ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: core-js
   ```
2. **pnpm 10 only** — pnpm 11 dropped `onlyBuiltDependencies` for `allowBuilds` (and no longer reads the `pnpm` field in `package.json`), so the allowlist was silently ignored on pnpm 11.

Same class of bug as the Astro starter — see tinacms/tina-astro-starter#59 and tinacms/tinacms#7031.

## Fix

- Add `core-js` to the allowlist.
- Add an `allowBuilds` map so build scripts run on **both** pnpm 10 and 11.

## Verify

`rm -rf node_modules && pnpm install` → no `ERR_PNPM_IGNORED_BUILDS`. Confirmed clean on pnpm 10.33.4 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)